### PR TITLE
update to new interfaces

### DIFF
--- a/lib/dB.ml
+++ b/lib/dB.ml
@@ -46,7 +46,7 @@ let qubesdb_vchan_port =
 
 let send t ?(path="") ?(data="") ty =
   let data = Cstruct.of_string data in
-  let hdr = make_msg_header ~ty ~path ~data_len:(Cstruct.len data) in
+  let hdr = make_msg_header ~ty ~path ~data_len:(Cstruct.length data) in
   QV.send t [hdr; data]
 
 let recv t =

--- a/lib/formats.ml
+++ b/lib/formats.ml
@@ -496,7 +496,7 @@ http://ccrc.web.nthu.edu.tw/ezfiles/16/1016/img/598/v14n_xen.pdf
   let make_with_header ~window ~ty body =
     (** see qubes-gui-agent-linux/include/txrx.h:#define write_message *)
     (** TODO consider using Cstruct.add_len *)
-    let body_len = Cstruct.len body in
+    let body_len = Cstruct.length body in
     let msg = Cstruct.create (sizeof_msg_header + body_len) in
     let()= set_msg_header_ty     msg (msg_type_to_int ty) in
     let()= set_msg_header_window msg window in
@@ -504,7 +504,7 @@ http://ccrc.web.nthu.edu.tw/ezfiles/16/1016/img/598/v14n_xen.pdf
     let() = Cstruct.blit
         (* src, srcoff: *) body 0
         (* dst, dstoff: *) msg sizeof_msg_header
-        (* length: *)      Cstruct.(len body)
+        (* length: *)      Cstruct.(length body)
     in msg
 
   let make_msg_mfndump ~window ~width ~height ~mfns =
@@ -660,7 +660,7 @@ module Rpc_filecopy = struct
   ]
 
   let make_result_header_ext last_filename =
-    let namelen = Cstruct.len last_filename in
+    let namelen = Cstruct.length last_filename in
     let msg = Cstruct.create (sizeof_result_header_ext + namelen) in
     set_result_header_ext_last_namelen msg (Int32.of_int namelen);
     Cstruct.blit (* src  srcoff *) last_filename 0

--- a/lib/gUI.ml
+++ b/lib/gUI.ml
@@ -83,7 +83,7 @@ let decode_CLIPBOARD_DATA buf =
   let len = get_msg_clipboard_data_len buf |> Int32.to_int in
   match
     Int32.compare (get_msg_clipboard_data_len buf) 0l = -1
-    || Cstruct.len buf + sizeof_msg_clipboard_data <> len with
+    || Cstruct.length buf + sizeof_msg_clipboard_data <> len with
   | true ->
     Logs.warn (fun m -> m "Got invalid CLIPBOARD_DATA msg from dom0");
     UNIT ()

--- a/lib/ipv4/qubesdb_ipv4.ml
+++ b/lib/ipv4/qubesdb_ipv4.ml
@@ -2,8 +2,8 @@ module Make
     (D: Qubes.S.DB)
     (R: Mirage_random.S)
     (C: Mirage_clock.MCLOCK)
-    (Ethernet : Mirage_protocols.ETHERNET)
-    (Arp : Mirage_protocols.ARP) = struct
+    (Ethernet : Ethernet.S)
+    (Arp : Arp.S) = struct
   include Static_ipv4.Make(R)(C)(Ethernet)(Arp)
   let connect db ethif arp =
     let (>>=?) ip f = match ip with

--- a/lib/ipv4/qubesdb_ipv4.mli
+++ b/lib/ipv4/qubesdb_ipv4.mli
@@ -2,10 +2,10 @@ module Make
     (D : Qubes.S.DB)
     (R : Mirage_random.S)
     (C : Mirage_clock.MCLOCK)
-    (Ethernet : Mirage_protocols.ETHERNET)
-    (Arp : Mirage_protocols.ARP) : sig
+    (Ethernet : Ethernet.S)
+    (Arp : Arp.S) : sig
 
-  include Mirage_protocols.IPV4
+  include Tcpip.Ip.S with type ipaddr = Ipaddr.V4.t
   val connect : D.t -> Ethernet.t -> Arp.t -> t Lwt.t
   (** [connect db ethernet arp] attempts to use the provided [db]
    *  to look up the correct IPV4 information, and construct

--- a/lib/msg_chan.ml
+++ b/lib/msg_chan.ml
@@ -24,7 +24,7 @@ module Make (F : Formats.FRAMING) = struct
   }
 
   let rec read_exactly t size =
-    let avail = Cstruct.len t.buffer in
+    let avail = Cstruct.length t.buffer in
     if avail >= size then (
       let retval = Cstruct.sub t.buffer 0 size in
       t.buffer <- Cstruct.shift t.buffer size;
@@ -50,7 +50,7 @@ module Make (F : Formats.FRAMING) = struct
 
   let recv_raw t : Cstruct.t S.or_eof Lwt.t =
     Lwt_mutex.with_lock t.read_lock @@ fun () ->
-    if Cstruct.len t.buffer > 0 then (
+    if Cstruct.length t.buffer > 0 then (
       let data = t.buffer in
       t.buffer <- Cstruct.create 0;
       return (`Ok data)

--- a/mirage-qubes-ipv4.opam
+++ b/mirage-qubes-ipv4.opam
@@ -15,12 +15,13 @@ build: [
 depends: [
   "dune"  {>= "1.0"}
   "mirage-qubes" {= version}
-  "tcpip" { >= "5.0.0" }
+  "tcpip" { >= "7.0.0" }
   "ipaddr" { >= "3.0.0" }
   "mirage-random" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
-  "mirage-protocols" { >= "4.0.0" }
-  "cstruct" { >= "1.9.0" }
+  "ethernet" {>= "3.0.0"}
+  "arp" {>= "3.0.0"}
+  "cstruct" { >= "6.0.0" }
   "lwt"
   "logs" { >= "0.5.0" }
   "ocaml" { >= "4.06.0" }

--- a/mirage-qubes.opam
+++ b/mirage-qubes.opam
@@ -14,7 +14,7 @@ build: [
 
 depends: [
   "dune"  {>= "1.0"}
-  "cstruct" { >= "2.2.0" }
+  "cstruct" { >= "6.0.0" }
   "ppx_cstruct"
   "vchan-xen" { >= "6.0.0" }
   "mirage-xen" { >= "6.0.0" }


### PR DESCRIPTION
This PR updates the code to the new interfaces for Ethernet, ARP and tcpip-v4.

So far I can confirm that the current master for qubes-mirage-firewall is compiling and booting fine and that the `[qubes.rexec] client connected, other end wants to use protocol version 3, continuing with version 2` message isn't anymore in the logs (with `[qubes.rexec] client connected, using protocol version 3` instead).
